### PR TITLE
Files should be created if it doesn't exists

### DIFF
--- a/SyncOMatic.Core.Tests/DiffFixture.cs
+++ b/SyncOMatic.Core.Tests/DiffFixture.cs
@@ -164,5 +164,26 @@
                 Assert.Throws<MissingSourceException>(() => som.Diff(map));
             }
         }
+
+        [Test]
+        public void CanDetectBlobCreationWhenTargetTreeFolderDoesNotExist()
+        {
+            var sourceBlob = new Parts("Particular/SyncOMatic.TestRepository", TreeEntryTargetType.Blob, "blessed-source", "new-file.txt");
+            var destBlob = new Parts("Particular/SyncOMatic.TestRepository", TreeEntryTargetType.Blob, "consumer-one", "IDoNotExist/MeNeither/new-file.txt");
+
+            var map = new Mapper()
+                .Add(sourceBlob, destBlob);
+
+            Diff diff;
+            using (var som = BuildSUT())
+            {
+                diff = som.Diff(map);
+            }
+
+            Assert.AreEqual(1, diff.Count());
+            Assert.NotNull(diff.Single().Key.Sha);
+            Assert.AreEqual(1, diff.Single().Value.Count());
+            Assert.Null(diff.Single().Value.Single().Sha);
+        }
     }
 }

--- a/SyncOMatic.Core/GitHubGateway.cs
+++ b/SyncOMatic.Core/GitHubGateway.cs
@@ -230,6 +230,14 @@ namespace SyncOMatic.Core
 
             var parent = TreeFrom(source.ParentTreePart, throwsIfNotFound);
 
+            if (parent == null)
+            {
+                if (throwsIfNotFound)
+                    throw new MissingSourceException(string.Format("[{0}: {1}] doesn't exist.", source.ParentTreePart.Type, source.ParentTreePart.Url));
+
+                return null;
+            }
+
             var blobName = source.Path.Split('/').Last();
             var blobEntry = parent.Item2.Tree.FirstOrDefault(ti => ti.Type == TreeType.Blob && ti.Path == blobName);
 

--- a/SyncOMatic.Core/SyncOMatic.cs
+++ b/SyncOMatic.Core/SyncOMatic.cs
@@ -128,7 +128,18 @@
 
         string BuildTargetTree(TargetTree tt)
         {
-            var newTree = BuildNewTreeFrom(gw.TreeFrom(tt.Current, true).Item2);
+            var treeFrom = gw.TreeFrom(tt.Current, false);
+
+            NewTree newTree;
+            if (treeFrom != null)
+            {
+                var destParentTree = treeFrom.Item2;
+                newTree = BuildNewTreeFrom(destParentTree);
+            }
+            else
+            {
+                newTree = new NewTree();
+            }
 
             foreach (var st in tt.SubTreesToUpdate.Values)
             {


### PR DESCRIPTION
When trying to sync a blob it and possibly the directory should be created if it doesn't exist

In this case we where trying to sync service matrix which lacks a src/ (added it manually to work around for now)
