### PR TITLE
Fix NewTree entries ordering

### DIFF
--- a/SyncOMatic.Tests/SyncOMatic.Tests.csproj
+++ b/SyncOMatic.Tests/SyncOMatic.Tests.csproj
@@ -53,6 +53,7 @@
     <Compile Include="RepoToSync.cs" />
     <Compile Include="SyncFixture.cs" />
     <Compile Include="SyncItem.cs" />
+    <Compile Include="TreeSortingFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SyncOMatic.Tests/TreeSortingFixture.cs
+++ b/SyncOMatic.Tests/TreeSortingFixture.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Octokit;
+using SyncOMatic;
+
+[TestFixture]
+public class TreeSortingFixture
+{
+    [Test]
+    public void canCorrectlySortTreeEntries()
+    {
+        /*
+            $ git init .
+            Initialized empty Git repository in d:/sort/.git/
+            $ echo a > base
+            $ mkdir foo
+            $ echo b > foo/one
+            $ mkdir foo.bar
+            $ echo b > foo.bar/one
+            $
+            $ git add foo/one
+            $ git add foo.bar/one
+            $ git add base
+            $
+            $ git commit -m "sort"
+             3 files changed, 3 insertions(+)
+             create mode 100644 base
+             create mode 100644 foo.bar/one
+             create mode 100644 foo/one
+            $
+            $ git ls-tree HEAD
+            100644 blob 78981922613b2afb6025042ff6bd878ac1994e85    base
+            040000 tree 6130ff146e70f13cdd304cf9c2b1795a5ec5715c    foo.bar
+            040000 tree 6130ff146e70f13cdd304cf9c2b1795a5ec5715c    foo
+         */
+        var list = new List<NewTreeItem>
+                   {
+                       new NewTreeItem { Path = "foo", Mode = "040000", Sha = "07753f428765ac1afe2020b24e40785869bd4a85" },
+                       new NewTreeItem { Path = "foo.bar", Mode = "040000", Sha = "07753f428765ac1afe2020b24e40785869bd4a85" },
+                       new NewTreeItem { Path = "base", Mode = "100644", Sha = "d95f3ad14dee633a758d2e331151e950dd13e4ed" },
+                   };
+
+        list.Sort(new NewTreeItemComparer());
+
+        Assert.AreEqual("base", list[0].Path);
+        Assert.AreEqual("foo.bar", list[1].Path);
+        Assert.AreEqual("foo", list[2].Path);
+    }
+}

--- a/SyncOMatic/GitHubGateway.cs
+++ b/SyncOMatic/GitHubGateway.cs
@@ -24,6 +24,8 @@ namespace SyncOMatic
         readonly string blobStoragePath;
         const string DEFAULT_CREDENTIALS_KEY = "Default";
 
+        static NewTreeItemComparer newTreeItemComparer = new NewTreeItemComparer();
+
         public GitHubGateway(IEnumerable<Tuple<Credentials, string>> credentialsPerRepos, IWebProxy proxy, Action<LogEntry> logCallBack)
         {
             SetupClientCache(credentialsPerRepos, Credentials.Anonymous, proxy);
@@ -330,6 +332,11 @@ namespace SyncOMatic
         {
             var client = ClientFor(destOwner, destRepository);
             var createdTree = client.GitDatabase.Tree.Create(destOwner, destRepository, newTree).Result;
+
+            //TODO: Remove when GitHub tree creation is fixed
+            var sorted = new List<NewTreeItem>(newTree.Tree);
+            sorted.Sort(newTreeItemComparer);
+            newTree.Tree = sorted;
 
             log("API Query - Create tree '{0}' in '{1}/{2}'.",
                 createdTree.Sha.Substring(0, 7), destOwner, destRepository);

--- a/SyncOMatic/NewTreeItemComparer.cs
+++ b/SyncOMatic/NewTreeItemComparer.cs
@@ -1,0 +1,24 @@
+namespace SyncOMatic
+{
+    using System;
+    using System.Collections.Generic;
+    using Octokit;
+
+    public class NewTreeItemComparer : IComparer<NewTreeItem>
+    {
+        public int Compare(NewTreeItem x, NewTreeItem y)
+        {
+            return string.Compare(NormalizedPath(x), NormalizedPath(y), StringComparison.Ordinal);
+        }
+
+        private string NormalizedPath(NewTreeItem nti)
+        {
+            if (nti.Mode != "040000")
+            {
+                return nti.Path;
+            }
+
+            return nti.Path + "/";
+        }
+    }
+}

--- a/SyncOMatic/SyncOMatic.csproj
+++ b/SyncOMatic/SyncOMatic.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="NewTreeItemComparer.cs" />
     <Compile Include="Parts.cs" />
     <Compile Include="Mapper.cs" />
     <Compile Include="GitHubGateway.cs" />


### PR DESCRIPTION
As pointed at by @peff, it looks like GH API **[Tree creation](https://developer.github.com/v3/git/trees/#create-a-tree)** doesn't properly order entries in a git.git compliant way.

This led to the creation of a wrongly sorted Tree in Particular/NServiceBus@ec5cb5ea8bb667fa59cb544c64c076a2408a2792.

In the Tree below, `NServiceBus` should appear after `NServiceBus.snk`

```
$ git ls-tree ec5cb5ea8bb667fa59cb544c64c076a2408a2792:src
040000 tree 7f2da57e545dc67c3b56504109fb9a4e2a0824c7    ConventionBasedHandlers
040000 tree 66006ac466bf64457b2454300fd3d5180cf4023e    NServiceBus
040000 tree 3bd21ea75cc2b0efe0bab91a12dc7729459d7b09    NServiceBus.AcceptanceTesting
040000 tree a0bb408bbeaed47e726deb95917fe9f509a41ae4    NServiceBus.AcceptanceTests
040000 tree c31ea36c357159099f190f902332cdceaabbe441    NServiceBus.Core
040000 tree cae40685e42c19ec65ee2c7c49950997b51f6415    NServiceBus.Core.Tests
040000 tree c35e1066fea66f59120877640adb20950b89ade9    NServiceBus.Core.Tests.x86
040000 tree fb30e4c83299113a44e5a3eba3206e5421cca83c    NServiceBus.Distributor.MSMQ
040000 tree 7aea2d05cd6c2bb76906af1c2379cb71596def24    NServiceBus.Hosting.Tests
040000 tree 9bbad3e2637eed822c1a5fb28fcfc833a62cfba3    NServiceBus.Hosting.Windows
040000 tree d9b9af79fa3802c03302bf29d634707a60b2b302    NServiceBus.Logging.Tests
040000 tree d2b5c39d06671459973cf3add1c202eac5b17600    NServiceBus.PerformanceTests
040000 tree be66045e16d0bd1a7b9fdf2c4055064107924bc0    NServiceBus.SagaPersisters.InMemory.Tests
040000 tree ea555c81c770c7cb45162bac8ee31dc9aa022446    NServiceBus.Serializers.XML.XsdGenerator
040000 tree 578e1f8c50e242cb5c5ce90ae054d3f13568fea0    NServiceBus.Testing
040000 tree 2246701d0d816669d36f4bbf4e02ecdf8c204983    NServiceBus.Testing.Tests
100644 blob 047d0c6df80981bc5ad5992b6207f99b5d3dea72    NServiceBus.sln
100644 blob 1a34c021dbc82ffb79d82f834d84ca5db9cee61b    NServiceBus.sln.DotSettings
100644 blob 6fa7ddec107b33bd6da190c08275d6c10af3be7d    NServiceBus.snk
040000 tree 307890ef1c524ec20dc0482203c455041c13d1b9    ObjectBuilder.Autofac
040000 tree 033811a6c2e8506d23ab34fa1d86156ddd2f6038    ObjectBuilder.CastleWindsor
040000 tree bdde381a31dc75ed13c6dffc0ced4feb27c0a53a    ObjectBuilder.Ninject
040000 tree f247d2ff4e7493c54c8b2bc3dce05f5e8c8496e3    ObjectBuilder.Spring
040000 tree a299f7bb058b8809890821cbc5318b4d6779f78e    ObjectBuilder.StructureMap
040000 tree 68b3a886777e4b3ce59bf6914e5b3fe4f2c67e1f    ObjectBuilder.Tests
040000 tree 3fd69319bd2e6f7c76f58256a594ad512dd2f4b3    ObjectBuilder.Unity
040000 tree d0befefbb1f4024d3a8d707427a78071a0b24660    ReturnToSourceQueue
040000 tree 67348900fcdbad5391605849dd7b0761bb95fe3f    licenseinstaller
100644 blob e013ea0e3f4feefee70c375cf0bdf21458723b21    scaffolding.config
```

This fix works around this at the SyncOMatic level. Maybe a similar fix should be done at the `Octokit.Net` (/cc @shiftkey @haacked) level until this is fixed upstream at the API level.

:warning: Do not merge this until properly reviewed :warning: 
