### PR TITLE
[WIP] Support multiple source and multiple target repositories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,31 +21,42 @@ https://nuget.org/packages/GitHubSync/
 ```cs
 // Create a new RepoSync
 var repoSync = new RepoSync(
+    log: Console.WriteLine,
+    syncMode: SyncMode.IncludeAllByDefault);
+
+// Add source repo(s)
+repoSync.AddSourceRepository(new RepositoryInfo(
     // Valid credentials for the source repo and all target repos
     credentials: octokitCredentials,
-    sourceOwner: "UserOrOrg",
-    sourceRepository: "TheSingleSourceRepository",
-    branch: "master",
-    log: Console.WriteLine);
+    owner: "UserOrOrg",
+    repository: "TheSingleSourceRepository",
+    branch: "master"));
 
-// Add sources(s)
+// Add sources(s), only allowed when SyncMode == ExcludeAllByDefault
 repoSync.AddBlob("sourceFile.txt");
 repoSync.AddBlob("code.cs");
 
-// Add repo target(s)
-repoSync.AddTarget(
+// Remove sources(s), only allowed when SyncMode == IncludeAllByDefault
+repoSync.AddBlob("sourceFile.txt");
+repoSync.AddBlob("code.cs");
+
+// Add target repo(s)
+repoSync.AddTargetRepository(new RepositoryInfo(
+    credentials: octokitCredentials,
     owner: "UserOrOrg",
     repository: "TargetRepo1",
-    branch: "master");
-// Omitting owner will use the sourceOwner passed in to RepoSync
-repoSync.AddTarget(
+    branch: "master"));
+
+repoSync.AddTargetRepository(new RepositoryInfo(
+    credentials: octokitCredentials,
+    owner: "UserOrOrg",
     repository: "TargetRepo2",
-    branch: "master");
+    branch: "master"));
 
 // Run the sync
 await repoSync.Sync(syncOutput: SyncOutput.MergePullRequest);
 ```
-<sup>[snippet source](/src/Tests/Snippets.cs#L10-L37)</sup>
+<sup>[snippet source](/src/Tests/Snippets.cs#L10-L48)</sup>
 <!-- endsnippet -->
 
 

--- a/src/GitHubSync/GitHubGateway.cs
+++ b/src/GitHubSync/GitHubGateway.cs
@@ -83,14 +83,10 @@ class GitHubGateway : IDisposable
         log($"Downloading blob from '{downloadUrl}'");
 
         using (var client = new HttpClient())
+        using (var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
+        using (var streamToReadFrom = await response.Content.ReadAsStreamAsync())
         {
-            using (var response = await client.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
-            {
-                using (var streamToReadFrom = await response.Content.ReadAsStreamAsync())
-                {
-                    await streamToReadFrom.CopyToAsync(targetStream);
-                }
-            }
+             await streamToReadFrom.CopyToAsync(targetStream);
         }
     }
 

--- a/src/GitHubSync/GitHubGateway.cs
+++ b/src/GitHubSync/GitHubGateway.cs
@@ -96,7 +96,7 @@ class GitHubGateway : IDisposable
 
     public async Task<bool> HasOpenPullRequests(string owner, string name, string prTitle)
     {
-        var pullRequests = await this.client.PullRequest.GetAllForRepository(owner, name);
+        var pullRequests = await client.PullRequest.GetAllForRepository(owner, name);
 
         return pullRequests.Any(x => string.Equals(x.Title, prTitle, StringComparison.OrdinalIgnoreCase));
     }

--- a/src/GitHubSync/GitHubSync.csproj
+++ b/src/GitHubSync/GitHubSync.csproj
@@ -9,7 +9,8 @@
   <ItemGroup>
     <PackageReference Include="ConfigureAwait.Fody" Version="3.1.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="4.2.1" PrivateAssets="All" />
-    <PackageReference Include="Octokit" Version="0.32.0"/>
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0" />
+    <PackageReference Include="Octokit" Version="0.32.0" />
   </ItemGroup>
 
 </Project>

--- a/src/GitHubSync/IParts.cs
+++ b/src/GitHubSync/IParts.cs
@@ -1,2 +1,2 @@
-﻿internal interface IParts
+﻿public interface IParts
 { }

--- a/src/GitHubSync/ManualSyncItem.cs
+++ b/src/GitHubSync/ManualSyncItem.cs
@@ -1,0 +1,11 @@
+﻿namespace GitHubSync
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public class ManualSyncItem
+    {
+        public string Path { get; set; }
+    }
+}

--- a/src/GitHubSync/Mapper.cs
+++ b/src/GitHubSync/Mapper.cs
@@ -1,4 +1,4 @@
-﻿class Mapper : MapperBase
+﻿public class Mapper : MapperBase
 {
     public Mapper Add(Parts from, Parts to)
     {

--- a/src/GitHubSync/MapperBase.cs
+++ b/src/GitHubSync/MapperBase.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
-abstract class MapperBase
+public abstract class MapperBase
 {
     Dictionary<Parts, ICollection<Parts>> toBeAddedOrUpdatedEntries = new Dictionary<Parts, ICollection<Parts>>();
     List<Parts> toBeRemovedEntries = new List<Parts>();

--- a/src/GitHubSync/Parts.cs
+++ b/src/GitHubSync/Parts.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using GitHubSync;
 
-class Parts : IParts, IEquatable<Parts>
+public class Parts : IParts, IEquatable<Parts>
 {
     Lazy<Parts> parent;
     Lazy<Parts> root;

--- a/src/GitHubSync/RepoSync.cs
+++ b/src/GitHubSync/RepoSync.cs
@@ -18,7 +18,7 @@ namespace GitHubSync
 
         public RepoSync(Action<string> log = null, List<string> labelsToApplyOnPullRequests = null, SyncMode syncMode = SyncMode.IncludeAllByDefault)
         {
-            this.log = log;
+            this.log = log ?? Console.WriteLine;
             this.labelsToApplyOnPullRequests = labelsToApplyOnPullRequests;
             this.syncMode = syncMode;
         }
@@ -79,7 +79,7 @@ namespace GitHubSync
             targets.Add(targetRepository);
         }
 
-        public async Task<SyncContext> CalculateItemsToSync(RepositoryInfo targetRepository)
+        public async Task<SyncContext> CalculateSyncContext(RepositoryInfo targetRepository)
         {
             var syncContext = new SyncContext(targetRepository);
 
@@ -109,7 +109,7 @@ namespace GitHubSync
 
                         includedPaths.Add(item);
 
-                        if (manualSyncItems.Any(x => string.Equals(x.Path, item, StringComparison.OrdinalIgnoreCase)))
+                        if (manualSyncItems.Any(x => item.StartsWith(x.Path, StringComparison.OrdinalIgnoreCase)))
                         {
                             switch (syncMode)
                             {
@@ -190,7 +190,7 @@ namespace GitHubSync
                         continue;
                     }
 
-                    var syncContext = await CalculateItemsToSync(targetRepository);
+                    var syncContext = await CalculateSyncContext(targetRepository);
 
                     if (syncContext.Diff.ToBeAddedOrUpdatedEntries.Count() == 0)
                     {

--- a/src/GitHubSync/RepositoryInfo.cs
+++ b/src/GitHubSync/RepositoryInfo.cs
@@ -1,0 +1,20 @@
+﻿namespace GitHubSync
+{
+    using Octokit;
+
+    public class RepositoryInfo
+    {
+        public RepositoryInfo(Credentials credentials, string owner, string repository, string branch)
+        {
+            Credentials = credentials;
+            Owner = owner;
+            Repository = repository;
+            Branch = branch;
+        }
+
+        public Credentials Credentials { get; }
+        public string Owner { get; }
+        public string Repository { get; }
+        public string Branch { get; }
+    }
+}

--- a/src/GitHubSync/SyncContext.cs
+++ b/src/GitHubSync/SyncContext.cs
@@ -1,0 +1,18 @@
+﻿namespace GitHubSync
+{
+    using System.Collections.Generic;
+
+    public class SyncContext
+    {
+        public SyncContext(RepositoryInfo targetRepository)
+        {
+            TargetRepository = targetRepository;
+        }
+
+        public RepositoryInfo TargetRepository { get; }
+
+        public string Description { get; set; }
+
+        public Mapper Diff { get; set; }
+    }
+}

--- a/src/GitHubSync/SyncItem.cs
+++ b/src/GitHubSync/SyncItem.cs
@@ -1,4 +1,4 @@
-﻿class SyncItem
+﻿public class SyncItem
 {
     public Parts Parts { get; set; }
     public bool ToBeAdded { get; set; }

--- a/src/GitHubSync/SyncMode.cs
+++ b/src/GitHubSync/SyncMode.cs
@@ -1,0 +1,9 @@
+﻿namespace GitHubSync
+{
+    public enum SyncMode
+    {
+        IncludeAllByDefault,
+
+        ExcludeAllByDefault
+    }
+}

--- a/src/Tests/RepoSyncTests.cs
+++ b/src/Tests/RepoSyncTests.cs
@@ -9,25 +9,29 @@ public class RepoSyncTests : TestBase
     public Task SyncPr()
     {
         var credentials = CredentialsHelper.Credentials;
-        var repoSync = new RepoSync(credentials, "SimonCropp", "GitHubSync.TestRepository", "source", WriteLog);
-        repoSync.AddBlob("sourceFile.txt");
+        var repoSync = new RepoSync(WriteLog);
+
+        repoSync.AddSourceRepository(new RepositoryInfo(credentials, "SimonCropp", "GitHubSync.TestRepository", "source"));
+        //repoSync.AddBlob("sourceFile.txt");
         repoSync.RemoveBlob("IDoNotExist/MeNeither.txt");
         repoSync.RemoveBlob("a/b/c/file.txt");
         repoSync.RemoveBlob("a/b/file.txt");
-        repoSync.AddTarget("SimonCropp", "GitHubSync.TestRepository", "target");
+        repoSync.AddTargetRepository(new RepositoryInfo(credentials, "SimonCropp", "GitHubSync.TestRepository", "target"));
 
-        return repoSync.Sync();
+        return repoSync.Sync(SyncOutput.CreatePullRequest);
     }
 
     [Fact]
     public Task SyncPrMerge()
     {
         var credentials = CredentialsHelper.Credentials;
-        var repoSync = new RepoSync(credentials, "SimonCropp", "GitHubSync.TestRepository", "source", WriteLog);
-        repoSync.AddBlob("sourceFile.txt");
+        var repoSync = new RepoSync(WriteLog);
+
+        repoSync.AddSourceRepository(new RepositoryInfo(credentials, "SimonCropp", "GitHubSync.TestRepository", "source"));
+        //repoSync.AddBlob("sourceFile.txt");
         repoSync.RemoveBlob("IDoNotExist/MeNeither.txt");
         repoSync.RemoveBlob("README.md");
-        repoSync.AddTarget("SimonCropp", "GitHubSync.TestRepository", "targetForMerge");
+        repoSync.AddTargetRepository(new RepositoryInfo(credentials, "SimonCropp", "GitHubSync.TestRepository", "targetForMerge"));
 
         return repoSync.Sync(SyncOutput.MergePullRequest);
     }
@@ -35,11 +39,14 @@ public class RepoSyncTests : TestBase
     [Fact]
     public Task SyncCommit()
     {
-        var repoSync = new RepoSync(CredentialsHelper.Credentials, "SimonCropp", "GitHubSync.TestRepository", "source", WriteLog);
-        repoSync.AddBlob("sourceFile.txt");
+        var credentials = CredentialsHelper.Credentials;
+        var repoSync = new RepoSync(WriteLog);
+
+        repoSync.AddSourceRepository(new RepositoryInfo(credentials, "SimonCropp", "GitHubSync.TestRepository", "source"));
+        //repoSync.AddBlob("sourceFile.txt");
         repoSync.RemoveBlob("IDoNotExist/MeNeither.txt");
         repoSync.RemoveBlob("README.md");
-        repoSync.AddTarget("SimonCropp", "GitHubSync.TestRepository", "targetForCommit");
+        repoSync.AddTargetRepository(new RepositoryInfo(credentials, "SimonCropp", "GitHubSync.TestRepository", "targetForCommit"));
 
         return repoSync.Sync(SyncOutput.CreateCommit);
     }

--- a/src/Tests/Snippets.cs
+++ b/src/Tests/Snippets.cs
@@ -10,26 +10,37 @@ public class Snippets
         #region usage
         // Create a new RepoSync
         var repoSync = new RepoSync(
+            log: Console.WriteLine,
+            syncMode: SyncMode.IncludeAllByDefault);
+
+        // Add source repo(s)
+        repoSync.AddSourceRepository(new RepositoryInfo(
             // Valid credentials for the source repo and all target repos
             credentials: octokitCredentials,
-            sourceOwner: "UserOrOrg",
-            sourceRepository: "TheSingleSourceRepository",
-            branch: "master",
-            log: Console.WriteLine);
+            owner: "UserOrOrg",
+            repository: "TheSingleSourceRepository",
+            branch: "master"));
 
-        // Add sources(s)
+        // Add sources(s), only allowed when SyncMode == ExcludeAllByDefault
         repoSync.AddBlob("sourceFile.txt");
         repoSync.AddBlob("code.cs");
 
-        // Add repo target(s)
-        repoSync.AddTarget(
+        // Remove sources(s), only allowed when SyncMode == IncludeAllByDefault
+        repoSync.AddBlob("sourceFile.txt");
+        repoSync.AddBlob("code.cs");
+
+        // Add target repo(s)
+        repoSync.AddTargetRepository(new RepositoryInfo(
+            credentials: octokitCredentials,
             owner: "UserOrOrg",
             repository: "TargetRepo1",
-            branch: "master");
-        // Omitting owner will use the sourceOwner passed in to RepoSync
-        repoSync.AddTarget(
+            branch: "master"));
+
+        repoSync.AddTargetRepository(new RepositoryInfo(
+            credentials: octokitCredentials,
+            owner: "UserOrOrg",
             repository: "TargetRepo2",
-            branch: "master");
+            branch: "master"));
 
         // Run the sync
         await repoSync.Sync(syncOutput: SyncOutput.MergePullRequest);


### PR DESCRIPTION
Solves both #48 and #49 

This way, it's possible to combine multiple source template repositories into a single "template" and apply them one by one to multiple targets.

At the moment it's not possible yet to manually customize the result of the source templates, but that's something that could (easily) be added in the future.

If the maintainer agrees on the set up, I will continue this path and fix the tests.