### PR TITLE
[BUG] pull request name uses source branch instead of target branch

### DIFF
--- a/src/GitHubSync/GitHubGateway.cs
+++ b/src/GitHubSync/GitHubGateway.cs
@@ -392,7 +392,7 @@ class GitHubGateway :
     public async Task<int> CreatePullRequest(string owner, string repository, string branch, string targetBranch,
         bool merge, string description)
     {
-        var newPullRequest = new NewPullRequest($"GitHubSync update - {branch}", branch, targetBranch);
+        var newPullRequest = new NewPullRequest($"GitHubSync update - {targetBranch}", branch, targetBranch);
 
         if (!string.IsNullOrWhiteSpace(description))
         {


### PR DESCRIPTION
And that means that GitHubSync believes no PR is there for the branch it is checking, which leads to another PR being created, and so forth...

Today we just had an endless loop of PR's being created in our automation because of this. 🙂 