### PR TITLE
Add a flag to skip the collaborator check

### DIFF
--- a/src/GitHubSync/RepoSync.cs
+++ b/src/GitHubSync/RepoSync.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using Octokit;
 
 namespace GitHubSync;
@@ -9,6 +9,7 @@ public class RepoSync
     List<string>? labelsToApplyOnPullRequests;
     SyncMode? syncMode;
     Credentials? defaultCredentials;
+    bool skipCollaboratorCheck;
     List<ManualSyncItem> manualSyncItems = new();
     List<RepositoryInfo> sources = new();
     List<RepositoryInfo> targets = new();
@@ -17,12 +18,14 @@ public class RepoSync
         Action<string>? log = null,
         List<string>? labelsToApplyOnPullRequests = null,
         SyncMode? syncMode = SyncMode.IncludeAllByDefault,
-        Credentials? defaultCredentials = null)
+        Credentials? defaultCredentials = null,
+        bool skipCollaboratorCheck = false)
     {
         this.log = log ?? Console.WriteLine;
         this.labelsToApplyOnPullRequests = labelsToApplyOnPullRequests;
         this.syncMode = syncMode;
         this.defaultCredentials = defaultCredentials;
+        this.skipCollaboratorCheck = skipCollaboratorCheck;
     }
 
     public void AddBlob(string path, string? target = null) =>
@@ -190,7 +193,7 @@ public class RepoSync
                 continue;
             }
 
-            var sync = await syncer.Sync(syncContext.Diff, syncOutput, labelsToApplyOnPullRequests, syncContext.Description);
+            var sync = await syncer.Sync(syncContext.Diff, syncOutput, labelsToApplyOnPullRequests, syncContext.Description, skipCollaboratorCheck);
             var createdSyncBranch = sync.FirstOrDefault();
 
             if (createdSyncBranch == null)


### PR DESCRIPTION
When RepoSync is run using a GitHubApp JWT token, the `GetAllForCurrent` used in the [collaborator check](https://github.com/SimonCropp/GitHubSync/blob/main/src/GitHubSync/Syncer.cs#L124) will fail with an HTTP 403 Forbidden and the following payload:

```
{
    "message": "Resource not accessible by integration",
    "documentation_url": "https://docs.github.com/rest/reference/repos#list-repositories-for-the-authenticated-user"
}
```

The [GitHub API documentation](https://docs.github.com/en/rest/repos/repos#list-repositories-for-the-authenticated-user) for this call lacks the "Works with GitHub Apps" checkmark indicating that it is likely not supported under the context of a GitHub App.  

This PR adds a flag to skip the collaborator check which avoids the call to `GetAllForCurrent`.  
